### PR TITLE
Updates for OpenSSL > 1.1.0

### DIFF
--- a/dh.cpp
+++ b/dh.cpp
@@ -148,11 +148,7 @@ openssl_unique_ptr<DH> make_dh (const unsigned char* prime, size_t prime_len, co
 		throw Openssl_error(ERR_get_error());
 	}
 
-	if ((dh->p = BN_bin2bn(prime, prime_len, NULL)) == NULL) {
-		throw Openssl_error(ERR_get_error());
-	}
-
-	if ((dh->g = BN_bin2bn(generator, generator_len, NULL)) == NULL) {
+	if (!DH_set0_pqg(dh.get(), BN_bin2bn(prime, prime_len, NULL), NULL, BN_bin2bn(generator, generator_len, NULL))) {
 		throw Openssl_error(ERR_get_error());
 	}
 

--- a/dh.cpp
+++ b/dh.cpp
@@ -148,14 +148,14 @@ openssl_unique_ptr<DH> make_dh (const unsigned char* prime, size_t prime_len, co
 		throw Openssl_error(ERR_get_error());
 	}
 
-  BIGNUM* p = NULL;
-  BIGNUM* g = NULL;
-  if ((p = BN_bin2bn(prime, prime_len, NULL)) == NULL) {
+	BIGNUM* p = NULL;
+	BIGNUM* g = NULL;
+	if ((p = BN_bin2bn(prime, prime_len, NULL)) == NULL) {
 		throw Openssl_error(ERR_get_error());
-  }
-  if ((g = BN_bin2bn(generator, generator_len, NULL)) == NULL) {
+	}
+	if ((g = BN_bin2bn(generator, generator_len, NULL)) == NULL) {
 		throw Openssl_error(ERR_get_error());
-  }
+	}
 	if (!DH_set0_pqg(dh.get(), p, NULL, g)) {
 		throw Openssl_error(ERR_get_error());
 	}

--- a/dh.cpp
+++ b/dh.cpp
@@ -148,7 +148,15 @@ openssl_unique_ptr<DH> make_dh (const unsigned char* prime, size_t prime_len, co
 		throw Openssl_error(ERR_get_error());
 	}
 
-	if (!DH_set0_pqg(dh.get(), BN_bin2bn(prime, prime_len, NULL), NULL, BN_bin2bn(generator, generator_len, NULL))) {
+  BIGNUM* p = NULL;
+  BIGNUM* g = NULL;
+  if ((p = BN_bin2bn(prime, prime_len, NULL)) == NULL) {
+		throw Openssl_error(ERR_get_error());
+  }
+  if ((g = BN_bin2bn(generator, generator_len, NULL)) == NULL) {
+		throw Openssl_error(ERR_get_error());
+  }
+	if (!DH_set0_pqg(dh.get(), p, NULL, g)) {
 		throw Openssl_error(ERR_get_error());
 	}
 

--- a/rsa_client.cpp
+++ b/rsa_client.cpp
@@ -85,7 +85,7 @@ int	Rsa_client::rsa_private_encrypt (int flen, const unsigned char* from, unsign
 int	Rsa_client::rsa_finish (RSA* rsa)
 {
 	delete reinterpret_cast<Rsa_client_data*>(RSA_get_app_data(rsa));
-	if (const auto default_finish = RSA_get_default_method()->finish) {
+	if (const auto default_finish = RSA_meth_get_finish(RSA_get_default_method())) {
 		return (*default_finish)(rsa);
 	} else {
 		return 1;
@@ -94,14 +94,14 @@ int	Rsa_client::rsa_finish (RSA* rsa)
 
 const RSA_METHOD*	Rsa_client::get_rsa_method ()
 {
-	static RSA_METHOD ops;
-	if (!ops.rsa_priv_enc) {
-		ops = *RSA_get_default_method();
-		ops.rsa_priv_enc = rsa_private_encrypt;
-		ops.rsa_priv_dec = rsa_private_decrypt;
-		ops.finish = rsa_finish;
+	static RSA_METHOD* ops = NULL;
+	if (ops == NULL) {
+		ops = RSA_meth_dup(RSA_get_default_method());
+		RSA_meth_set_priv_enc(ops, rsa_private_encrypt);
+		RSA_meth_set_priv_dec(ops, rsa_private_decrypt);
+		RSA_meth_set_finish(ops, rsa_finish);
 	}
-	return &ops;
+	return ops;
 }
 
 openssl_unique_ptr<EVP_PKEY>	Rsa_client::load_private_key (uintptr_t key_id, RSA* public_rsa)
@@ -111,12 +111,10 @@ openssl_unique_ptr<EVP_PKEY>	Rsa_client::load_private_key (uintptr_t key_id, RSA
 		throw Openssl_error(ERR_get_error());
 	}
 
-	rsa->n = BN_dup(public_rsa->n);
-	if (!rsa->n) {
-		throw Openssl_error(ERR_get_error());
-	}
-	rsa->e = BN_dup(public_rsa->e);
-	if (!rsa->e) {
+	const BIGNUM* n;
+	const BIGNUM* e;
+	RSA_get0_key(public_rsa, &n, &e, NULL);
+	if (!RSA_set0_key(rsa.get(), BN_dup(n), BN_dup(e), NULL)) {
 		throw Openssl_error(ERR_get_error());
 	}
 

--- a/rsa_client.cpp
+++ b/rsa_client.cpp
@@ -111,10 +111,18 @@ openssl_unique_ptr<EVP_PKEY>	Rsa_client::load_private_key (uintptr_t key_id, RSA
 		throw Openssl_error(ERR_get_error());
 	}
 
-	const BIGNUM* n;
-	const BIGNUM* e;
-	RSA_get0_key(public_rsa, &n, &e, NULL);
-	if (!RSA_set0_key(rsa.get(), BN_dup(n), BN_dup(e), NULL)) {
+	const BIGNUM* pk_n = NULL;
+	const BIGNUM* pk_e = NULL;
+	BIGNUM* n = NULL;
+	BIGNUM* e = NULL;
+	RSA_get0_key(public_rsa, &pk_n, &pk_e, NULL);
+	if ((n = BN_dup(pk_n)) == NULL) {
+		throw Openssl_error(ERR_get_error());
+	}
+	if ((e = BN_dup(pk_e)) == NULL) {
+		throw Openssl_error(ERR_get_error());
+	}
+	if (!RSA_set0_key(rsa.get(), n, e, NULL)) {
 		throw Openssl_error(ERR_get_error());
 	}
 


### PR DESCRIPTION
This PR replaces direct access of OpenSSL structures (which are no longer directly available) with new getters / setters to support OpenSSL > 1.1.0.

See the [OpenSSL 1.1.0 Changes](https://wiki.openssl.org/index.php/OpenSSL_1.1.0_Changes) page on the OpenSSL wiki for more info.